### PR TITLE
docs: add guide for library usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ func main() {
 }
 ```
 
+See the [Library Usage Guide](docs/guides/library-usage.md) for more ways to integrate Hermes into your Go projects.
+
 ## Development
 
 ### Prerequisites

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Welcome to the comprehensive documentation for Hermes, a high-performance Go web
 - [Installation & Setup](guides/installation.md) - Quick start guide and installation instructions
 - [Basic Usage](guides/basic-usage.md) - Your first steps with Hermes
 - [CLI Usage](guides/cli-usage.md) - Command line interface documentation
+- [Library Usage](guides/library-usage.md) - Using Hermes as a Go module
 
 ### API Reference
 - [Parser API](api/parser.md) - Core parser interface and methods
@@ -21,6 +22,7 @@ Welcome to the comprehensive documentation for Hermes, a high-performance Go web
 ### Guides & Tutorials
 - [CLI Usage](guides/cli-usage.md) - Detailed CLI commands and flags
 - [Basic Usage](guides/basic-usage.md) - Common patterns and examples
+- [Library Usage](guides/library-usage.md) - Integration as a library
 
 ### Development
 - See repository README for development setup, testing, and build commands

--- a/docs/guides/library-usage.md
+++ b/docs/guides/library-usage.md
@@ -1,0 +1,107 @@
+# Library Usage
+
+This guide explains how to use Hermes as a Go module in your own projects. It covers
+installation, basic parsing, configuration options and high-throughput batch
+processing.
+
+## Installation
+
+Add Hermes to your module with `go get`:
+
+```bash
+go get github.com/BumpyClock/hermes
+```
+
+If you are starting a new project remember to initialize a module first:
+
+```bash
+go mod init example.com/myproject
+```
+
+## Basic Example
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/BumpyClock/hermes/pkg/parser"
+)
+
+func main() {
+    p := parser.New()
+
+    result, err := p.Parse("https://example.com/article", nil)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    if result.IsError() {
+        log.Fatal(result.Message)
+    }
+
+    fmt.Printf("Title: %s\n", result.Title)
+    fmt.Printf("Content: %s\n", result.Content)
+}
+```
+
+## Configuring the Parser
+
+`ParserOptions` control extraction behaviour:
+
+```go
+opts := &parser.ParserOptions{
+    ContentType:   "markdown",             // html, markdown, text or json
+    FetchAllPages: true,                    // hint to follow next_page_url
+    Headers:       map[string]string{
+        "User-Agent": "MyBot/1.0",
+    },
+}
+result, err := p.Parse(url, opts)
+```
+
+## Batch Processing
+
+For high volume workloads use `NewHighThroughputParser` which reuses workers and
+connections:
+
+```go
+urls := []string{
+    "https://example.com/1",
+    "https://example.com/2",
+}
+
+ht := parser.NewHighThroughputParser(&parser.ParserOptions{ContentType: "text"})
+results, err := ht.BatchParse(urls, nil)
+if err != nil {
+    log.Fatal(err)
+}
+
+for i, res := range results {
+    if res.IsError() {
+        log.Printf("failed to parse %s: %s", urls[i], res.Message)
+        ht.ReturnResult(res)
+        continue
+    }
+    fmt.Printf("%s -> %d words\n", res.Title, res.WordCount)
+    ht.ReturnResult(res)
+}
+```
+
+## Error Handling and Pagination
+
+Hermes returns a `Result` object even when extraction fails. Always check
+`result.IsError()` and the `Message` field before using the content. When a
+`next_page_url` is detected you can fetch subsequent pages yourself or use the
+`FetchAllPages` option (multi-page merging is still in development).
+
+## Next Steps
+
+- Review the [Parser API](../api/parser.md) for a complete list of options
+  and result fields.
+- Browse [examples](../examples/basic.md) for more advanced patterns.
+- Learn about [custom extractors](custom-extractors.md) to improve extraction
+  for specific sites.
+


### PR DESCRIPTION
## Summary
- document how to install and use Hermes as a Go module
- link new guide from documentation index and README

## Testing
- `go test ./...` *(fails: undefined: GenericSiteNameExtractor)*

------
https://chatgpt.com/codex/tasks/task_e_68aa73acfc9c8327b254e75b23043094