### PR TITLE
chore: ignore node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,6 @@ debug
 .claude/cclsp.json
 
 test-output/
-benchmark/node_modules/
+
+# Node dependencies
 node_modules/


### PR DESCRIPTION
## Summary
- ignore node modules in git
- clean up lingering node_modules directory

## Testing
- `go test ./... -vet=off` *(fails: no output, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68ac00707d888327b0f8d16d065c0ed6